### PR TITLE
Update mc_path_sampling.py

### DIFF
--- a/PyMEMENTO/mc_path_sampling.py
+++ b/PyMEMENTO/mc_path_sampling.py
@@ -81,7 +81,7 @@ class MCPathSampler:
             for j in range(1, self.MODELS_PER_WINDOW + 1):
                 self.universes[-1].append(
                     mda.Universe(
-                        self.FOLDER + f"morph{i}/protein.B9999{str(j).zfill(4)}.pdb"
+                        self.FOLDER + f"morph{i}/protein.B9999{str(j).zfill(4)}.pdb", in_memory=True
                     )
                 )
 


### PR DESCRIPTION
Fixes `Cannot open file or stream in mode='rt'` when loading trajectories by loading them into memory. It also makes the rest of the process faster.